### PR TITLE
shrink headers in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,24 @@
-# Feature or Problem
+## Feature or Problem
 <!---
 Briefly describe the reason for this pull request: the feature being added or problem being solved.
 --->
 
-# Related Issues
+## Related Issues
 <!--- 
 Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
 --->
 
-# Release Information
+## Release Information
 <!---
 Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
 --->
 
-# Consumer Impact
+## Consumer Impact
 <!---
 Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
 --->
 
-# Testing
+## Testing
 <!---
 Declare the testing information for this pull request
 --->
@@ -43,17 +43,17 @@ Tested on platform(s)
 - [ ] aarch64-darwin
 - [ ] x86_64-windows
 
-## Unit Test(s)
+### Unit Test(s)
 <!---
 Indicate if unit tests were added or modified, and if so, which ones 
 --->
 
-## Acceptance or Integration
+### Acceptance or Integration
 <!---
 Indicate any changes or additions to the acceptance or integration test suite 
 --->
 
-## Manual Verification
+### Manual Verification
 <!---
 Mandatory. Indicate the steps that you took to verify that this pull request works 
 --->


### PR DESCRIPTION
## Feature or Problem
I think the headers are a bit too big :)

## Related Issues
N/A

## Release Information
N/A

## Consumer Impact
Slightly more of a PR description can fit on a screen now. This is NOT backwards compatible. Users will need to visually compensate.

## Testing

### Unit Test(s)


### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
The template rendered on this PR reflects the changes made in the PR